### PR TITLE
Add `.pytest_cache` to `.gitignore` <#12>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ ENV/
 
 # models - https://drive.google.com/file/d/13L-yKsb0TYMb3UF68-XOvO8Lf-efTRiT/view?usp=sharing
 models/fine_tuned_model/*
+
+# pytest cache
+.pytest_cache/


### PR DESCRIPTION
# Add `.pytest_cache` to `.gitignore` <#12>

## PR Description
This PR adds `.pytest_cache/` to `.gitignore` to prevent temporary pytest cache files from being tracked in the repository.

## Why
- `.pytest_cache/` is automatically created by `pytest` when running tests.  
- It does not need to be committed.  
- Keeps the repository clean from temporary test artifacts.
