### PR TITLE
Fix issue category example <#31>

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ If hooks fail, your commit is blocked until you fix the issues. This prevents CI
 
 ## Reporting Issues
 
-**Include the category in your issue title** (e.g., `[bug] Memory leak in matcher`, `[docs] Clarify contribution guidelines`).
+**Include the category in your issue title** (e.g., `[bug] Memory leak in matcher`, `[documentation] Clarify contribution guidelines`).
 
 This helps you categorize the issue type before submitting and helps maintainers prioritize and label issues during triage.
 


### PR DESCRIPTION
PR fixes issue #31

Hi, 

I changed the e.g. in Issue categories from `[docs]` to `[documentation]` so that is matches with the [CONTRIBUTING.md](https://github.com/easonanalytica/company_name_matcher/blob/dev/CONTRIBUTING.md) and the labels which you have used.

Thanks!