### PR TITLE
📝 Fix link format in data README for country codes

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -95,7 +95,7 @@ canonical_name,variation,country_code,source
 ## File Requirements
 
 - Apache Parquet format with zstd compression
-- Valid country codes (check [countrycode.csv](../_reference/countrycode.csv), `ISO2` column)
+- Valid country codes (check [countrycode.csv](_reference/countrycode.csv), `ISO2` column)
 - No duplicate pairs within the same file
 - One pair per row
 


### PR DESCRIPTION
Hi @easonanalytica ,

The link in the [data contribution guide](https://github.com/easonanalytica/company_name_matcher/blob/dev/data/README.md) for the file [countrycode.csv](https://github.com/easonanalytica/company_name_matcher/blob/dev/data/_reference/countrycode.csv) redirects to nowhere, so I fixed the link.

Thanks!