### PR TITLE
Add Unit Tests as Pre-Commit Hook

### DIFF
--- a/.github/workflows/test-pr-to-dev.yml
+++ b/.github/workflows/test-pr-to-dev.yml
@@ -52,36 +52,28 @@ jobs:
         python -m py_compile tests/*.py
 
   lint:
-    # run only when PR has 'under-review' label (maintainer-controlled CI to save resources)
-    if: github.event.pull_request.head.ref != 'dev' && !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'under-review')
+    if: github.event.pull_request.head.ref != 'dev' &&
+        !github.event.pull_request.draft &&
+        contains(github.event.pull_request.labels.*.name, 'under-review')
     runs-on: ubuntu-latest
-
+  
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
+  
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+  
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+  
+      - name: Run pre-commit on changed files only
+        uses: pre-commit/action@v3.0.1
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
-
-    - name: Install linting dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install black flake8 bandit
-
-    - name: Check code formatting with Black
-      run: |
-        black --check --diff src/ tests/ --config pyproject.toml
-
-    - name: Run basic linting
-      run: |
-        flake8 src/ tests/ --count --select=E9,F63,F7,F82 --show-source --statistics
-        flake8 src/ tests/ --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics
-
-    - name: Run security check
-      run: |
-        bandit -r src/ -c .bandit
 
   validate-data:
     # run only when PR has 'under-review' label and contains data changes

--- a/.github/workflows/test-pr-to-dev.yml
+++ b/.github/workflows/test-pr-to-dev.yml
@@ -73,6 +73,8 @@ jobs:
   
       - name: Run pre-commit on changed files only
         uses: pre-commit/action@v3.0.1
+        with:
+          extra-args: --hook black --hook bandit --hook flake8-strict --hook flake8-regular
 
 
   validate-data:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
   - repo: https://github.com/pycqa/flake8
     rev: 7.0.0
     hooks:
-      - id: flake8
+      - id: flake8-strict
         name: flake8-strict
         args:
           - --select=E9,F63,F7,F82
@@ -20,7 +20,7 @@ repos:
   - repo: https://github.com/pycqa/flake8
     rev: 7.0.0
     hooks:
-      - id: flake8
+      - id: flake8-regular
         name: flake8-regular
         args:
           - --max-line-length=120

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,32 @@
 repos:
-  # Black code formatter (matches CI: black --check --diff src/ tests/)
+  # Black
   - repo: https://github.com/psf/black
     rev: 23.12.1
     hooks:
       - id: black
         language_version: python3
-        args: [--line-length=120]  # Match CI max-line-length=120
+        args: [--line-length=120]
 
-  # Flake8 linter (matches CI: --max-line-length=120 --max-complexity=10)
+  # Flake8 – strict pass
   - repo: https://github.com/pycqa/flake8
     rev: 7.0.0
     hooks:
       - id: flake8
+        name: flake8-strict
+        args:
+          - --select=E9,F63,F7,F82
 
-  # Bandit security linter (matches CI: bandit -r src/ -c .bandit)
+  # Flake8 – regular pass
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        name: flake8-regular
+        args:
+          - --max-line-length=120
+          - --max-complexity=10
+
+  # Bandit
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.6
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,15 @@ repos:
       - id: bandit
         args: [-c, .bandit]
         exclude: ^tests/
+        
+  # Unit Tests
+  - repo: local
+    hooks:
+      - id: pytest-unit
+        name: Run Pytest Unit Tests
+        entry: pytest tests/test_batch_processing.py tests/test_default_matcher.py
+        language: system
+        pass_filenames: false
+        files: |
+          ^src/.*|^tests/test_batch_processing.py$|^tests/test_default_matcher.py$
+


### PR DESCRIPTION
# Add Unit Tests as Pre-Commit Hook  (#54 )

## Summary
This PR introduces a new **pre-commit hook for running unit tests** to ensure that code changes affecting `src/` or unit test files themselves are validated before committing.  
The hook only runs for **unit tests**, explicitly excluding long-running integration tests.  

Additionally, the **lint CI job** has been updated to skip this hook, since all tests are handled in a separate job. This avoids redundant test execution and keeps the lint workflow fast.

---

## What Changed
### ✅ Pre-commit Hook for Unit Tests
- Added a local hook named `pytest-unit` in `pre-commit-config.yaml`.
- It runs only the two unit test files (`test_batch_processing.py`, `test_default_matcher.py` and triggers **only when files in `src/` or the unit test files** are modified.
- Integration tests in `tests/` are excluded, ensuring pre-commit runs quickly on commits/PRs.

### ✅ Lint CI Update
- The GitHub Actions lint job now **skips the `pytest-unit` hook**.
- All other hooks (black, flake8, bandit) continue to run as before.
- Prevents unit tests from running twice, since they are already covered by a dedicated test job.

---

## Why This Matters
- 🔄 **Prevents broken code from being committed** by running unit tests locally before push.
- ⚡ **Keeps lint CI fast** by skipping tests that are already run in a dedicated test job.
- 🧹 **Separates unit tests from integration tests**, preventing long-running tests from slowing pre-commit.
- ✅ **Ensures consistency**: CI and local pre-commit workflows now correctly enforce the same unit test rules.
