### PR TITLE
chore:🪝add hook for data validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,14 @@ repos:
       - id: bandit
         args: [-c, .bandit]
         exclude: ^tests/
+
+  # Data Validation
+  - repo: local
+    hooks:
+      - id: validate-data
+        name: Validate Data Contributions
+        entry: python scripts/validate_data.py
+        language: system
+        pass_filenames: false
+        files: ^data/.*\.parquet$
+


### PR DESCRIPTION
# Add Pre-Commit Hook for Data Validation (#65 )

## Summary
This PR adds a new **pre-commit hook** to automatically validate data contributions.  
The hook runs `scripts/validate_data.py` whenever a `.parquet` file in the `data/` is added or modified.  
This ensures that invalid data does not get committed even if contributors forget to run the validation script manually.

---

## What Changed
### ✅ New Pre-commit Hook
- Added a local hook named `validate-data` in `pre-commit-config.yaml`.
- The hook triggers **only when `.parquet` files in `data/` are modified or added**.
- Validation failures prevent the commit, ensuring only valid data is committed.


### ✅ Benefits
- Ensures **data integrity** automatically on commit.
- Reduces human error by making validation part of the workflow.
- Provides contributors with immediate feedback about invalid data contributions.
- Integrates seamlessly with existing pre-commit setup without affecting other hooks.

---
