### PR TITLE
fix: Make flake8 CI action to read from the .`flake8` file

### DIFF
--- a/.github/workflows/test-pr-to-dev.yml
+++ b/.github/workflows/test-pr-to-dev.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Run basic linting
       run: |
         flake8 src/ tests/ --count --select=E9,F63,F7,F82 --show-source --statistics
-        flake8 src/ tests/ --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics
+        flake8 src/ tests/ --count --exit-zero --statistics
 
     - name: Run security check
       run: |


### PR DESCRIPTION
This PR makes sure that the CI lint action reads from the `.flake8` file by removing command line arguments that can override the configuration file. This is related to #52 .