### PR TITLE
chore:🪝Add pre-commit hook to run unit tests with pytest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,15 @@ repos:
       - id: bandit
         args: [-c, .bandit]
         exclude: ^tests/
+
+  - repo: local
+    hooks:
+      - id: unit-test
+        name: Run pytest for unit tests
+        entry: pytest tests/test_batch_processing.py tests/test_default_matcher.py
+        language: python       
+        pass_filenames: false  
+        files: |
+          ^src/.*\.py$|
+          ^tests/test_batch_processing\.py$|
+          ^tests/test_default_matcher\.py$


### PR DESCRIPTION
This PR runs unit tests (`test_default_matcher.py` and `test_batch_processing.py`) locally whenever changes are done to the tests themselves or whenever code is changed in the `src/` directory. This prevents bad code from being committed and gives contributors instant feedback. This handles issue #54 