### PR TITLE
chore:🪝Add pre-commit hook for data validation script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,14 @@ repos:
       - id: bandit
         args: [-c, .bandit]
         exclude: ^tests/
+
+  - repo: local
+    hooks:
+      - id: pytest-validate-data
+        name: Run pytest when validate_data.py changes
+        entry: pytest tests/test_validate_data.py
+        language: python
+        pass_filenames: false
+        files: |
+        ^scripts/validate_data\.py$|
+        ^tests/test_validate_data\.py$


### PR DESCRIPTION
This PR adds a pre-commit hook that runs whenever validate_data.py or test_validate_data.py is modified. This ensures that any changes to the validation script are automatically tested, helping contributors avoid forgetting to run the relevant tests. It improves code quality and reduces the risk of introducing errors in the data validation logic. This PR handles issue #70 .