### PR TITLE
chore:💡 Add return type hint to `test_leading_whitespace_detected()` function

### DIFF
--- a/tests/test_validate_data.py
+++ b/tests/test_validate_data.py
@@ -374,7 +374,7 @@ def test_titlecase_check_fail() -> None:
     assert out["CaseError: variation"][0] == "CaseError: variation is not in titlecase"
 
 
-def test_leading_whitespace_detected():
+def test_leading_whitespace_detected() -> None:
     df = pl.DataFrame({"canonical_name": ["  Apple Inc."]})
     out = run_whitespace_check(df)
 


### PR DESCRIPTION
Added the return type of `None` to the `test_leading_whitespace_detected()` in `test_validate_data.py`. This PR fixes issue #77.