### PR TITLE
chore:💡Add return type annotation to `test_non_utf8_column_is_ignored()`

### DIFF
--- a/tests/test_validate_data.py
+++ b/tests/test_validate_data.py
@@ -434,7 +434,7 @@ def test_no_whitespace_errors():
     assert out["DoubleWhiteSpaceError: canonical_name"][0] is None
 
 
-def test_non_utf8_column_is_ignored():
+def test_non_utf8_column_is_ignored() -> None:
     df = pl.DataFrame({"index": [1]})  # Int64 → should not create any error columns
     out = run_whitespace_check(df)
 


### PR DESCRIPTION
Added return type of `None` to the `test_non_utf8_column_is_ignored()` function in `test_validate_data.py`. This PR fixes issue #81.