### PR TITLE
chore: 🛠️ Fix Pyright import errors for `scripts/` and `src/`  

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,20 @@ ignore_missing_imports = true
 line-length = 120
 
 # Note: Flake8 configuration is in .flake8 file (flake8 doesn't read pyproject.toml by default)
+
+[tool.pyright]
+# Which folders to include for type checking
+include = ["."]
+
+# Extra paths for resolving imports outside the package
+extraPaths = ["src", "scripts"]
+
+# Enable strict type checking
+typeCheckingMode = "strict"
+
+# Optional: exclude caches or virtual environments
+exclude = [
+  "**/venv",
+  "**/.pytest_cache",
+  "**/__pycache__"
+]


### PR DESCRIPTION
# 🛠️ Fix Pyright import errors for `scripts/` and `src/`  

## Summary

This PR updates the Pyright configuration to fix unresolved import errors during type checking, without changing the runtime behavior of tests or the existing `conftest.py`.  This resolves issue #76 .

## Changes

- Added `extraPaths = ["src", "scripts"]` so Pyright can resolve:
  - `from company_name_matcher import ...` (library code in `src/`)  
  - `from validate_data import ...` (maintainer’s test import from `scripts/`)  
- Enabled `typeCheckingMode = "strict"` for rigorous type checking  
- Included exclusions for virtual environments and pytest caches  

## Motivation

The maintainer @easonanalytica  added `conftest.py` that modifies `sys.path` so pytest can run tests using `from validate_data import ...`. While this works at runtime, Pyright **cannot see `sys.path` modifications**, causing import errors.  

With this configuration:

- Pyright now correctly resolves imports from both the library and `scripts/`  
- Tests can still rely on `conftest.py` without modification  
- Static type checking is fully functional in strict mode  

## Notes / Future Improvements

While this fix works well for type checking, the **more robust solution** would be to structure the project so that `scripts/` is a proper Python package or move `validate_data.py` into the library package under `src/`. This would remove the need for `sys.path` hacks and make both runtime imports and type checking fully aligned with standard Python packaging.
