### PR TITLE
chore: Add type annotations to `default_matcher()`

### DIFF
--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -8,8 +8,8 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 
 @pytest.fixture
-def default_matcher():
-    def preprocess_name(name):
+def default_matcher()-> CompanyNameMatcher:
+    def preprocess_name(name: str) -> str:
         return re.sub(r"[^a-zA-Z0-9\s]", "", name.lower()).strip()
 
     return CompanyNameMatcher("paraphrase-multilingual-MiniLM-L12-v2", preprocess_fn=preprocess_name)


### PR DESCRIPTION
This PR adds type annotations to the `default_matcher()` function in `tests/test_batch_processing.py` file. This fixes issue #89.