### PR TITLE
chore: Add type annotations to `test_batch_find_matches_backward_compatibility()` and `test_n_jobs_parameter()`

### DIFF
--- a/src/company_name_matcher/company_name_matcher.py
+++ b/src/company_name_matcher/company_name_matcher.py
@@ -1,6 +1,6 @@
 import logging
 from sentence_transformers import SentenceTransformer
-from typing import List, Tuple, Union, Callable, Optional, Dict, cast
+from typing import List, Tuple, Union, Callable, Optional, Dict, overload
 import numpy as np
 from .vector_store import VectorStore
 import os
@@ -245,6 +245,30 @@ class CompanyNameMatcher:
         self.vector_store = VectorStore(np.array([[0]]), ["dummy"])  # Initialize with dummy data
         self.vector_store.load_index(load_dir)
 
+    @overload
+    def find_matches(
+        self,
+        target_company: str,
+        threshold: float = ...,
+        k: int = ...,
+        use_approx: bool = ...,
+        batch_size: int = ...,
+        n_jobs: int = ...,
+        n_probe_clusters: int = ...,
+    ) -> List[Tuple[str, float]]: ...
+
+    @overload
+    def find_matches(
+        self,
+        target_company: List[str],
+        threshold: float = ...,
+        k: int = ...,
+        use_approx: bool = ...,
+        batch_size: int = ...,
+        n_jobs: int = ...,
+        n_probe_clusters: int = ...,
+    ) -> List[List[Tuple[str, float]]]: ...
+
     def find_matches(
         self,
         target_company: Union[str, List[str]],
@@ -254,7 +278,10 @@ class CompanyNameMatcher:
         batch_size: int = 32,
         n_jobs: int = 1,
         n_probe_clusters: int = 1,
-    ) -> Union[List[Tuple[str, float]], List[List[Tuple[str, float]]]]:
+    ) -> Union[
+        List[Tuple[str, float]],
+        List[List[Tuple[str, float]]],
+    ]:
         """
         Find matching companies for a single company name or a list of names.
 
@@ -463,10 +490,7 @@ class CompanyNameMatcher:
         >>> matcher.batch_find_matches(["Acme", "Initech"], threshold=0.8)
         [[('Acme Corp', 1.0000001192092896)], [('Initech LLC', 1.0)]]
         """
-        return cast(
-            List[List[Tuple[str, float]]],
-            self.find_matches(target_companies, threshold, k, use_approx, batch_size, n_jobs),
-        )
+        return self.find_matches(target_companies, threshold, k, use_approx, batch_size, n_jobs)
 
     @staticmethod
     def _cosine_similarity(a: NDArray[np.floating], b: NDArray[np.floating]) -> NDArray[np.floating]:

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -133,7 +133,7 @@ def test_batch_find_matches_backward_compatibility(default_matcher: CompanyNameM
             assert abs(new_match[1] - old_match[1]) < 1e-6, "Similarity scores should be the same"
 
 
-def test_n_jobs_parameter(default_matcher, test_companies, tmp_path):
+def test_n_jobs_parameter(default_matcher: CompanyNameMatcher, test_companies: List[str], tmp_path: Path):
     # Build index
     index_dir = tmp_path / "test_njobs_index"
     default_matcher.build_index(test_companies, n_clusters=2, save_dir=str(index_dir))

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -3,6 +3,8 @@ import pytest
 from company_name_matcher import CompanyNameMatcher
 import time
 import re
+from typing import List
+from pathlib import Path
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
@@ -107,7 +109,7 @@ def test_batch_processing_performance(default_matcher, tmp_path):
     print(f"Speedup: {sequential_time/parallel_time:.2f}x")
 
 
-def test_batch_find_matches_backward_compatibility(default_matcher, test_companies, tmp_path):
+def test_batch_find_matches_backward_compatibility(default_matcher: CompanyNameMatcher, test_companies: List[str], tmp_path: Path):
     # Build index
     index_dir = tmp_path / "test_compat_index"
     default_matcher.build_index(test_companies, n_clusters=2, save_dir=str(index_dir))


### PR DESCRIPTION
This PR adds type annotations to the `test_batch_find_matches_backward_compatibility()` and `test_n_jobs_parameter()` functions in the `tests/test_batch_processing.py` file. This fixes issues #94 and #95.

To fix the type issues here, I had to add `overload` signatures to the `find_matches()` function in `src/company_name_matcher/company_name_matcher.py` file. This removes the ambiguity of using `Union`.

And once I converted to an overload signature, I removed an unnecessay `cast` call in `batch_find_matches()`