### PR TITLE
chore: Add type annotations to test_basic_company_comparison()

### DIFF
--- a/tests/test_default_matcher.py
+++ b/tests/test_default_matcher.py
@@ -14,7 +14,7 @@ def default_matcher():
     return CompanyNameMatcher("paraphrase-multilingual-MiniLM-L12-v2", preprocess_fn=preprocess_name)
 
 
-def test_basic_company_comparison(default_matcher):
+def test_basic_company_comparison(default_matcher: CompanyNameMatcher):
     test_cases = [
         ("Apple", "Microsoft Corporation", 0.34, 0.2),  # Expected low similarity
         ("Apple", "Apple Inc", 0.90, 0.2),  # Expected high similarity


### PR DESCRIPTION
This PR adds type annotations to the `test_basic_company_comparison()` function in the `tests/test_default_matcher.py` file. This fixes issue #103