### PR TITLE
chore: Add type annotations to `test_data()

### DIFF
--- a/tests/test_model_comparison.py
+++ b/tests/test_model_comparison.py
@@ -10,9 +10,9 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 
 @pytest.fixture
-def test_data():
+def test_data() -> pd.DataFrame:
     """Load the test data from CSV file."""
-    return pd.read_csv("tests/test_data.csv")
+    return pd.read_csv("tests/test_data.csv") #type: ignore
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR adds type annotations to the `test_data()` function in the `tests/test_model_comparison.py` file. This fixes issue #115.