### PR TITLE
chore: Add type annotations to `default_matcher()`

### DIFF
--- a/tests/test_model_comparison.py
+++ b/tests/test_model_comparison.py
@@ -26,10 +26,10 @@ def rapid_fuzz_matcher():
 
 
 @pytest.fixture
-def default_matcher():
+def default_matcher() -> CompanyNameMatcher:
     """Create a default CompanyNameMatcher."""
 
-    def preprocess_name(name):
+    def preprocess_name(name: str) -> str:
         return re.sub(r"[^a-zA-Z0-9\s]", "", name.lower()).strip()
 
     return CompanyNameMatcher("paraphrase-multilingual-MiniLM-L12-v2", preprocess_fn=preprocess_name)


### PR DESCRIPTION
This PR adds type annotations to the `default_matcher()` function in the `tests/test_model_comparison.py` file. This fixes issue #116.