### PR TITLE
chore: Remove unused type checker configurations (mypy, pytype, pyre)

### DIFF
--- a/.pyre-configuration
+++ b/.pyre-configuration
@@ -1,6 +1,0 @@
-{
-  "source_directories": ["src"],
-  "search_path": ["typings"],   # include local stubs
-  "typeshed": null,             # use default typeshed
-  "taint_models_path": []
-}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,6 @@ where = ["src"]
 [tool.setuptools.package-data]
 "company_name_matcher" = ["py.typed"]
 
-[tool.mypy]
-mypy_path = "typings"
-ignore_missing_imports = true
-
 [tool.black]
 line-length = 120
 

--- a/pytype.cfg
+++ b/pytype.cfg
@@ -1,4 +1,0 @@
-[pytype]
-python_version = 3.9
-input = src
-pythonpath = typings 


### PR DESCRIPTION
## Summary
This PR removes configuration files for type checkers that are no longer used, now that Pyright is the main type checker for the project.

## Changes
- Deleted `[tool.mypy]` section from `pyproject.toml`
- Removed `pytype.cfg`
- Removed `.pyre-configuration`

## Rationale
Maintaining multiple type checker configurations can cause confusion and adds unnecessary overhead. With Pyright as the single source of truth, these unused configs are redundant.

## Notes
No functional code changes; purely cleanup of configuration files.

This fixes issue #126.
